### PR TITLE
Update test-local script to prefer npx serve

### DIFF
--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -3,13 +3,16 @@
 echo "Testing cache invalidation locally..."
 
 # Start a simple local server to test the PWA
-if command -v python3 &> /dev/null; then
+if command -v npx &> /dev/null && npx serve -v > /dev/null 2>&1; then
+    echo "Starting local server with npx serve..."
+    npx serve -s src -p 8080
+elif command -v python3 &> /dev/null; then
     echo "Starting local server with Python 3..."
     cd src && python3 -m http.server 8080
 elif command -v python &> /dev/null; then
     echo "Starting local server with Python 2..."
     cd src && python -m SimpleHTTPServer 8080
 else
-    echo "Python not found. Please install Python or use another local server."
-    echo "You can also use: npx serve src -p 8080"
+    echo "Neither npx serve nor Python is available."
+    echo "Please install Node.js or Python to run a local server."
 fi


### PR DESCRIPTION
## Summary
- improve test-local.sh to use `npx serve` when available

## Testing
- `bash scripts/test-local.sh & sleep 2; kill $!` *(fails: port already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68550d54f2c88327a5f21c66a00ad4bd