### PR TITLE
Fix .DS_Store ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,7 @@ README.md
 .env
 .nyc_output
 coverage
-.ds_store
+.DS_Store
 *.log
 docker/docker-compose.yml
 docker/Dockerfile


### PR DESCRIPTION
## Summary
- fix ignoring of `.DS_Store` in Docker builds

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68550d2df31c8327891b54c45208c1e7