### PR TITLE
Fix update routine so playback isn't interrupted

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1231,8 +1231,7 @@ function showUpdateNotification() {
     
     document.body.appendChild(notification);
     
-    // Auto-reload after 5 seconds if user doesn't click
-    setTimeout(() => {
-        window.location.reload();
-    }, 5000);
+    // Previously the app would auto refresh after a short delay which
+    // interrupted playback.  We now only show the notification and let the
+    // user decide when to reload so playback continues uninterrupted.
 }


### PR DESCRIPTION
## Summary
- prevent automatic reload when an update is detected so playback continues

## Testing
- `node --check src/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68551b4be83c8327aa0b6a9977e6d0b1