### PR TITLE
Fix update notification message and service worker activation

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1203,6 +1203,8 @@ if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('/sw.js')
             .then(registration => {
                 console.log('SW registered: ', registration);
+                // Store registration for later use (e.g. sending messages)
+                window.swRegistration = registration;
                 
                 // Check for updates every time the app loads
                 registration.addEventListener('updatefound', () => {
@@ -1257,7 +1259,7 @@ function showUpdateNotification() {
     `;
     notification.innerHTML = `
         <strong>Update Available!</strong><br>
-        <small>Click to reload when ready (your playback will continue after reload)</small>
+        <small>Click to reload when ready</small>
     `;
     
     // Store the current playing state and station before reload
@@ -1268,12 +1270,16 @@ function showUpdateNotification() {
             sessionStorage.setItem('rrradio-playing-before-update', 'true');
             sessionStorage.setItem('rrradio-last-station-id', app.currentStation.id);
         }
+        // Activate waiting service worker so the latest version loads
+        if (window.swRegistration && window.swRegistration.waiting) {
+            window.swRegistration.waiting.postMessage({ type: 'SKIP_WAITING' });
+        }
         window.location.reload();
     });
     
     document.body.appendChild(notification);
     
     // Previously the app would auto refresh after a short delay which
-    // interrupted playback. We now only show the notification and let the
-    // user decide when to reload so playback continues uninterrupted.
+    // interrupted playback. We now show the notification and let the
+    // user decide when to reload.
 }

--- a/src/sw.js
+++ b/src/sw.js
@@ -20,8 +20,7 @@ const urlsToCache = [
 
 self.addEventListener('install', event => {
     console.log('Service Worker installing with cache:', CACHE_NAME);
-    // Force the waiting service worker to become the active service worker
-    self.skipWaiting();
+    // Do not call skipWaiting here so the new worker activates only after the user reloads
     
     event.waitUntil(
         caches.open(CACHE_NAME)


### PR DESCRIPTION
## Summary
- remove misleading claim about uninterrupted playback in update notification
- prevent service worker from activating immediately on install
- send `SKIP_WAITING` to waiting service worker when user reloads
- store registration object for later use

## Testing
- `bash scripts/test-local.sh` *(fails: cannot download npx packages due to no internet and runs python server)*

------
https://chatgpt.com/codex/tasks/task_e_68553d25248c832782679edf448b5a9f