### PR TITLE
Add beta indicator

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -71,6 +71,7 @@
             <h1>
                 <i class="fas fa-radio logo-icon"></i>
                 <span class="logo-text">Rrradio</span>
+                <span id="betaIndicator" class="beta-indicator" style="display:none">BETA</span>
             </h1>
             <div class="header-actions">
                 <button id="themeToggle" class="btn-theme-toggle" title="Toggle dark/light theme">

--- a/src/script.js
+++ b/src/script.js
@@ -18,8 +18,11 @@ class RadioApp {
             number: '1.3.3',
             build: this.generateBuildNumber(),
             date: this.formatBuildDate(),
-            codename: 'Frequency Shift'
+            codename: 'Frequency Shift',
+            isBeta: false
         };
+
+        this.detectBetaEnvironment();
         
         this.initializeEventListeners();
         this.renderStations();
@@ -296,7 +299,8 @@ class RadioApp {
     }
     
     showVersionDetails() {
-        const detailedInfo = `🎵 Rrradio v${this.version.number} "${this.version.codename}" - Built with ❤️ for radio lovers!`;
+        const betaText = this.version.isBeta ? ' Beta' : '';
+        const detailedInfo = `🎵 Rrradio v${this.version.number}${betaText} "${this.version.codename}" - Built with ❤️ for radio lovers!`;
         this.showNotification(detailedInfo, 5000); // Show for 5 seconds
         
         // Also log detailed info to console
@@ -1049,13 +1053,16 @@ class RadioApp {
         const appVersionEl = document.getElementById('appVersion');
         const buildNumberEl = document.getElementById('buildNumber');
         const buildDateEl = document.getElementById('buildDate');
-        
-        if (appVersionEl) appVersionEl.textContent = this.version.number;
+
+        if (appVersionEl) {
+            appVersionEl.textContent = this.version.number + (this.version.isBeta ? ' (beta)' : '');
+        }
         if (buildNumberEl) buildNumberEl.textContent = this.version.build;
         if (buildDateEl) buildDateEl.textContent = this.version.date;
         
         // Add version info to console for debugging
-        console.log(`Rrradio v${this.version.number} (${this.version.codename}) - Build ${this.version.build}`);
+        const betaFlag = this.version.isBeta ? ' beta' : '';
+        console.log(`Rrradio v${this.version.number}${betaFlag} (${this.version.codename}) - Build ${this.version.build}`);
     }
     
     generateBuildNumber() {
@@ -1074,11 +1081,26 @@ class RadioApp {
     formatBuildDate() {
         // Format the current date for display
         const now = new Date();
-        return now.toLocaleDateString('en-US', { 
-            year: 'numeric', 
-            month: 'long', 
+        return now.toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
             day: 'numeric'
         });
+    }
+
+    detectBetaEnvironment() {
+        const params = new URLSearchParams(window.location.search);
+        const hasBetaParam = params.has('beta');
+        const hostHasBeta = window.location.hostname.toLowerCase().includes('beta');
+        const isBeta = hasBetaParam || hostHasBeta;
+        this.version.isBeta = isBeta;
+
+        if (isBeta) {
+            const indicator = document.getElementById('betaIndicator');
+            if (indicator) {
+                indicator.style.display = 'inline-block';
+            }
+        }
     }
     
     // Restore playback state after update

--- a/src/styles.css
+++ b/src/styles.css
@@ -142,6 +142,17 @@ body {
     text-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
 }
 
+.beta-indicator {
+    background: var(--accent-color);
+    color: #fff;
+    font-size: 0.8rem;
+    padding: 2px 6px;
+    border-radius: 4px;
+    margin-left: 8px;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+}
+
 .logo-text {
     background: linear-gradient(135deg, var(--accent-color) 0%, #764ba2 50%, #ff6b6b 100%);
     -webkit-background-clip: text;


### PR DESCRIPTION
## Summary
- show BETA badge in header when beta URL is used
- style the beta badge
- detect beta environment in JS and reflect it in version info

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685560ac11c48327b6cffa2d58a1fb95