### PR TITLE
Handle stop playback indicator

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -370,6 +370,7 @@ class RadioApp {
         this.isPlaying = false;
         this.updatePlayerStatus('Ended');
         this.updatePlayPauseButton();
+        this.clearPlayingStations();
     }
 
     audioErrorHandler = (e) => {
@@ -379,6 +380,7 @@ class RadioApp {
             this.updatePlayerStatus('Error loading stream');
             this.isPlaying = false;
             this.updatePlayPauseButton();
+            this.clearPlayingStations();
         }
     }
 


### PR DESCRIPTION
## Summary
- clear `.playing` visual indicator when the audio stream ends or fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685563cc456c8327a2e14566302f784f