### PR TITLE
Fix playing indicator disappearing when reordering stations

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -894,6 +894,11 @@ class RadioApp {
             // Add drag-and-drop event listeners
             this.setupDragHandlers(card);
         });
+        
+        // Restore the playing indicator if a station is currently playing
+        if (this.currentStation && this.isPlaying) {
+            this.markStationAsPlaying();
+        }
     }
 
     setupDragHandlers(card) {
@@ -962,6 +967,11 @@ class RadioApp {
             
             // Re-render all the stations with the new order
             this.renderStations();
+            
+            // Restore the playing indicator if a station is currently playing
+            if (this.currentStation && this.isPlaying) {
+                this.markStationAsPlaying();
+            }
             
             // Show a notification of the reordering
             this.showNotification('Station order updated');


### PR DESCRIPTION
This pull request includes updates to the `RadioApp` class in `src/script.js` to ensure the playing indicator is restored when a station is currently playing. The changes improve user experience by maintaining the visual state of the app after certain actions.

Enhancements to playing indicator restoration:

* [`src/script.js`](diffhunk://#diff-978bff6f08d9f62278251257f4d62e5bf7e06dd48cf6db4bca16c37875a28e64R897-R901): Added logic in the `renderStations` method to restore the playing indicator if a station is currently playing (`this.currentStation` and `this.isPlaying` checks).
* [`src/script.js`](diffhunk://#diff-978bff6f08d9f62278251257f4d62e5bf7e06dd48cf6db4bca16c37875a28e64R971-R975): Added similar logic in the drag-and-drop reordering handler to ensure the playing indicator is restored after stations are reordered.

Closes #25 
