### PR TITLE
Fix/playing indicator gone after reordering

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -907,11 +907,37 @@ class RadioApp {
             e.dataTransfer.setData('text/plain', card.dataset.stationId);
             card.classList.add('dragging');
             
-            // Set drag image to the card itself
-            // Slight delay to allow the dragging class to take effect
-            setTimeout(() => {
-                e.dataTransfer.setDragImage(card, 20, 20);
-            }, 0);
+            // Create a custom drag image for better visual feedback, especially for playing stations
+            const isPlaying = card.classList.contains('playing');
+            if (isPlaying) {
+                // For playing stations, create a cleaner drag image without the pseudo elements
+                const dragImage = card.cloneNode(true);
+                dragImage.classList.add('drag-image');
+                dragImage.classList.add('dragging');
+                if (isPlaying) {
+                    dragImage.classList.add('playing-drag');
+                    dragImage.classList.remove('playing'); // Remove regular playing class to avoid pseudo-elements
+                }
+                
+                // Temporarily add to document to compute styles, but make it invisible
+                dragImage.style.position = 'absolute';
+                dragImage.style.top = '-9999px';
+                dragImage.style.opacity = '0';
+                document.body.appendChild(dragImage);
+                
+                // Use this custom element as drag image
+                e.dataTransfer.setDragImage(dragImage, 20, 20);
+                
+                // Clean up after a short delay
+                setTimeout(() => {
+                    document.body.removeChild(dragImage);
+                }, 100);
+            } else {
+                // For regular cards, use the standard approach
+                setTimeout(() => {
+                    e.dataTransfer.setDragImage(card, 20, 20);
+                }, 0);
+            }
         });
 
         card.addEventListener('dragend', () => {

--- a/src/script.js
+++ b/src/script.js
@@ -894,6 +894,11 @@ class RadioApp {
             // Add drag-and-drop event listeners
             this.setupDragHandlers(card);
         });
+        
+        // Restore the playing indicator if a station is currently playing
+        if (this.currentStation && this.isPlaying) {
+            this.markStationAsPlaying();
+        }
     }
 
     setupDragHandlers(card) {
@@ -962,6 +967,11 @@ class RadioApp {
             
             // Re-render all the stations with the new order
             this.renderStations();
+            
+            // Restore the playing indicator if a station is currently playing
+            if (this.currentStation && this.isPlaying) {
+                this.markStationAsPlaying();
+            }
             
             // Show a notification of the reordering
             this.showNotification('Station order updated');

--- a/src/styles.css
+++ b/src/styles.css
@@ -1191,6 +1191,19 @@ body {
     border: 2px dashed var(--accent-color);
 }
 
+/* Custom drag image for playing stations */
+.drag-image.playing-drag {
+    background: linear-gradient(to bottom right, var(--card-bg), rgba(var(--accent-color-rgb), 0.05));
+    border: 3px solid var(--accent-color);
+    box-shadow: 0 8px 20px rgba(var(--accent-color-rgb), 0.2);
+}
+
+/* This class won't have the ::after pseudo-element that causes visual glitches when dragging */
+.drag-image.playing-drag .station-info h3 {
+    color: var(--text-primary);
+    font-weight: 700;
+}
+
 /* Responsive design */
 @media (max-width: 768px) {
     .container {


### PR DESCRIPTION
This pull request enhances the drag-and-drop functionality in the `RadioApp` class and introduces styling improvements for custom drag images in the `src/styles.css` file. The key changes focus on improving the user experience when interacting with playing stations during drag-and-drop operations and ensuring the playing indicator is restored after certain actions.

### Drag-and-Drop Enhancements:
* [`src/script.js`](diffhunk://#diff-978bff6f08d9f62278251257f4d62e5bf7e06dd48cf6db4bca16c37875a28e64L905-R940): Added logic to create a custom drag image for playing stations, ensuring better visual feedback by removing pseudo-elements that cause glitches. The custom drag image is temporarily added to the document to compute styles and then cleaned up after use.

### Playing Indicator Restoration:
* [`src/script.js`](diffhunk://#diff-978bff6f08d9f62278251257f4d62e5bf7e06dd48cf6db4bca16c37875a28e64R897-R901): Ensured the playing indicator is restored when stations are re-rendered or reordered, improving continuity for the user. [[1]](diffhunk://#diff-978bff6f08d9f62278251257f4d62e5bf7e06dd48cf6db4bca16c37875a28e64R897-R901) [[2]](diffhunk://#diff-978bff6f08d9f62278251257f4d62e5bf7e06dd48cf6db4bca16c37875a28e64R997-R1001)

### Styling Improvements:
* [`src/styles.css`](diffhunk://#diff-4753b2e6427841425517139f09f1342c320338443447af46169dc0f43a0f2cf3R1194-R1206): Introduced new CSS rules for the custom drag image of playing stations, including enhanced visuals like a gradient background, solid border, and shadow effects. Also adjusted text styling for the drag image to maintain consistency.