### PR TITLE
Fix spacing between bottom stations and control panel

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -318,7 +318,8 @@ body {
 /* Main content */
 .main-content {
     flex: 1;
-    margin-bottom: 120px;
+    margin-bottom: 140px; /* Increased bottom margin for better spacing with the player */
+    padding-bottom: 20px; /* Additional padding at the bottom */
 }
 
 /* No stations message */
@@ -355,7 +356,7 @@ body {
     display: flex;
     flex-wrap: wrap;
     gap: 16px;
-    padding: 20px 0;
+    padding: 20px 0 30px 0; /* Increased bottom padding */
     overflow: visible;
 }
 


### PR DESCRIPTION
This pull request makes adjustments to the layout and spacing in the `src/styles.css` file to improve visual consistency and user experience. The changes primarily focus on increasing margins and padding for better spacing.

Layout and spacing improvements:

* [`src/styles.css`](diffhunk://#diff-4753b2e6427841425517139f09f1342c320338443447af46169dc0f43a0f2cf3L321-R322): Increased the bottom margin of `.main-content` from `120px` to `140px` and added `padding-bottom: 20px` to improve spacing with the player.
* [`src/styles.css`](diffhunk://#diff-4753b2e6427841425517139f09f1342c320338443447af46169dc0f43a0f2cf3L358-R359): Adjusted the padding of the flex container to include an additional bottom padding of `30px`, changing the padding from `20px 0` to `20px 0 30px 0`.