### PR TITLE
Bypass service worker for audio streams

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -53,6 +53,11 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+    // Let audio streams bypass the service worker to avoid stutter from cached/opaque responses
+    if (event.request.destination === 'audio' || event.request.headers.has('range')) {
+        return;
+    }
+
     // For app shell resources, use network-first strategy to get updates
     if (urlsToCache.some(url => event.request.url.includes(url.replace('/', '')))) {
         event.respondWith(


### PR DESCRIPTION
### Motivation

- Users reported intermittent audio stuttering where streams appear to rewind in small increments, likely caused by the service worker intercepting streaming/Range requests.
- The service worker's caching/interception of opaque or range requests can interfere with continuous audio playback and introduce small glitches.

### Description

- Added an early bypass in the service worker `src/sw.js` fetch handler to let audio streams go directly to the network when `event.request.destination === 'audio'` or the request contains a `Range` header.
- The change returns early for such requests so they are not handled by the network-first or cache-first logic that updates the app shell cache.

### Testing

- No automated tests were run for this change.
- Manual runtime verification is recommended by loading the app and playing a known streaming station to confirm stuttering is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69517c967df88327bbef3d5c7ee120c3)