### PR TITLE
Improve footer contrast

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -325,8 +325,10 @@ body {
 .site-footer {
     margin: 0 auto 140px;
     text-align: center;
-    font-size: 0.75rem;
-    color: var(--text-secondary);
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #ffffff;
+    text-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
 }
 
 /* No stations message */


### PR DESCRIPTION
### Motivation
- The site footer was too unobtrusive and hard to read against background elements.  
- Increase visibility and readability of footer content by improving contrast and weight.  

### Description
- Update `src/styles.css` `.site-footer` to increase `font-size` from `0.75rem` to `0.85rem`.  
- Add `font-weight: 500` and set `color: #ffffff` for higher contrast.  
- Add a subtle `text-shadow: 0 1px 4px rgba(0, 0, 0, 0.35)` to improve legibility over busy backgrounds.  

### Testing
- Served the app with `python -m http.server` and captured a full-page screenshot using a Playwright script, which completed successfully and produced `artifacts/footer-visible.png`.  
- No unit or integration tests were run because this is a static CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518da6799483279546a7347b1c1e9f)